### PR TITLE
added Si and B to the parameter list.

### DIFF
--- a/ad4_shared/AD4.1_bound.dat
+++ b/ad4_shared/AD4.1_bound.dat
@@ -118,3 +118,5 @@ atom_par G      4.00  0.150  33.5103  -0.00143  0.0  0.0  0  -1  -1  0	# Ring cl
 atom_par GA     4.00  0.150  33.5103  -0.00052  0.0  0.0  0  -1  -1  0	# Ring closure Glue Aromatic Carbon   # SF
 atom_par J      4.00  0.150  33.5103  -0.00143  0.0  0.0  0  -1  -1  0	# Ring closure Glue Aliphatic Carbon  # SF
 atom_par Q      4.00  0.150  33.5103  -0.00143  0.0  0.0  0  -1  -1  0	# Ring closure Glue Aliphatic Carbon  # SF
+atom_par Si     4.10  0.200  35.8235  -0.00143  0.0  0.0  0  -1  -1  6  # Non H-bonding Silicon
+atom_par B      3.84  0.155  29.6478  -0.00152  0.0  0.0  0  -1  -1  0  # Non H-bonding Boron

--- a/ad4_shared/AD4_parameters.dat
+++ b/ad4_shared/AD4_parameters.dat
@@ -116,3 +116,5 @@ atom_par G      4.00  0.150  33.5103  -0.00143  0.0  0.0  0  -1  -1  0	# Ring cl
 atom_par GA     4.00  0.150  33.5103  -0.00052  0.0  0.0  0  -1  -1  0	# Ring closure Glue Aromatic Carbon   # SF
 atom_par J      4.00  0.150  33.5103  -0.00143  0.0  0.0  0  -1  -1  0	# Ring closure Glue Aliphatic Carbon  # SF
 atom_par Q      4.00  0.150  33.5103  -0.00143  0.0  0.0  0  -1  -1  0	# Ring closure Glue Aliphatic Carbon  # SF
+atom_par Si     4.10  0.200  35.8235  -0.00143  0.0  0.0  0  -1  -1  6  # Non H-bonding Silicon
+atom_par B      3.84  0.155  29.6478  -0.00152  0.0  0.0  0  -1  -1  0  # Non H-bonding Boron


### PR DESCRIPTION
Added Silicon and Boron parameters to `AD4.1_bound.dat` and `AD4_parameters.dat` taken from Meeko: https://github.com/forlilab/Meeko/blob/07a38f8bac4aa9eef4ef30aa8e67475b15d517aa/meeko/gridbox.py#L159-L160

